### PR TITLE
Rewrite of mecab parsing

### DIFF
--- a/MecabNode.py
+++ b/MecabNode.py
@@ -5,13 +5,14 @@ class MecabNode:
         surface = string.split("\t")[0]
         features = string.split("\t")[1].split(",")
 
+        # note: parse results not in the dictionary don't have all 9 fields
         self.surface = surface
         self.pos = ".".join(features[:4]).replace(".*","")
         self.inflection_group = features[4].replace("*","")
         self.inflection_type = features[5].replace("*","")
-        self.base_form = features[6].replace("*","")
-        self.reading = features[7].replace("*","")
-        self.pronunciation = features[8].replace("*","")
+        self.base_form = features[6].replace("*","") if len(features) >= 7 else ""
+        self.reading = features[7].replace("*","") if len(features) >= 8 else ""
+        self.pronunciation = features[8].replace("*","") if len(features) >= 9 else ""
 
     def __repr__(self):
         return f'{self.surface},{self.pos},{self.inflection_group},{self.inflection_type},{self.base_form},{self.reading},{self.pronunciation}'

--- a/MecabNode.py
+++ b/MecabNode.py
@@ -1,0 +1,17 @@
+import MeCab
+
+class MecabNode:
+    def __init__(self, string):
+        surface = string.split("\t")[0]
+        features = string.split("\t")[1].split(",")
+
+        self.surface = surface
+        self.pos = ".".join(features[:4]).replace(".*","")
+        self.inflection_group = features[4].replace("*","")
+        self.inflection_type = features[5].replace("*","")
+        self.base_form = features[6].replace("*","")
+        self.reading = features[7].replace("*","")
+        self.pronunciation = features[8].replace("*","")
+
+    def __repr__(self):
+        return f'{self.surface},{self.pos},{self.inflection_group},{self.inflection_type},{self.base_form},{self.reading},{self.pronunciation}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ ptyprocess==0.7.0
 Pygments==2.10.0
 python-dateutil==2.8.2
 pyzmq==22.3.0
+simplejson==3.17.6
 six==1.16.0
 soupsieve==2.3.1
 tornado==6.1

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@ import subprocess
 import re
 import json
 from pathlib import Path
+from MecabNode import MecabNode
 
 from frequency_lists import FrequencyList
 
@@ -120,13 +121,18 @@ def parse_sentence(sentence: str, mt) -> list:
     mt - A mecab tagger. Create using MeCab.Tagger
     """
     filter_str = r'()./,!:?\uksa0123456789\t\r\s .'
-    parsed = mt.parseToNode(sentence)
+    parse_results = mt.parse(sentence).split("\n")
     words = []
-    while parsed:
-        word = re.sub(r'\s+', '', parsed.surface)
+
+    for line in parse_results:
+        # ignore mecab's EOS outputs and line without tabs
+        if line.startswith("EOS") or not "\t" in line:
+            continue
+
+        node = MecabNode(line)
+        word = re.sub(r'\s+', '', node.surface)
         for char in filter_str:
             word = word.replace(char, '')
         if len(word) >= 1:
             words.append(word)
-        parsed = parsed.next
     return words


### PR DESCRIPTION
I created a class to store all of the information we get from a mecab parse and changed the parsing method to parse() in order to avoid error with random bytes in the beginning of "surface".